### PR TITLE
UTF-8 Test Cases for length(), substr(), index(), and match()

### DIFF
--- a/toybox_awk_test/awk.test
+++ b/toybox_awk_test/awk.test
@@ -434,6 +434,7 @@ testcmd "match()" "'BEGIN{print match(\"bcdab\", \"ab\")}'" "4\n" "" ""
 testcmd "match() none" "'BEGIN{print match(\"ス\", \"deadbeef\")}'" "0\n" "" ""
 testcmd "match() utf8" "'{print match(\$0, \"ス\")}' < $FILES/utf8/japan.txt"\
   "5\n" "" ""
+testcmd "\\u" "'BEGIN{print \"\\u20\u255\"}' < /dev/null" " ɕ\n" "" ""
 
 testcmd "-b" "-b '{print length()}'< $FILES/utf8/japan.txt" "75\n" "" ""
 

--- a/toybox_awk_test/awk.test
+++ b/toybox_awk_test/awk.test
@@ -422,6 +422,17 @@ testcmd "tolower()" "'BEGIN{print tolower(\"abABcD\")}'" "ababcd\n" "" ""
 testcmd "substr()" "'BEGIN{print substr(\"abac\", 2, 2)}'" "ba\n" "" ""
 testcmd "atan2()" "'BEGIN{print substr(atan2(0, -1), 1, 5)}'" "3.141\n" "" ""
 testcmd "length()" "'{print length()}'" "1\n2\n0\n4\n" "" "a\n12\n\n6502"
+[ -n "$TEST_HOST" ] &&\
+  export LOCALE=en_US.UTF-8 LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+testcmd "length() utf8" "'{print length()}'< $FILES/utf8/japan.txt" "25\n" "" ""
+testcmd "substr() utf8" "'{print substr(\$0,2,1)}' < $FILES/utf8/arabic.txt" "ل\nأ\n" "" "" 
+testcmd "index() utf8" "'{print index(\$0, \"ス\")}' < $FILES/utf8/japan.txt"\
+  "5\n" "" ""
+testcmd "index() none" "'BEGIN{print index(\"ス\", \"deadbeef\")}'" "0\n" "" ""
+testcmd "match()" "'BEGIN{print match(\"bcdab\", \"ab\")}'" "4\n" "" ""
+testcmd "match() none" "'BEGIN{print match(\"ス\", \"deadbeef\")}'" "0\n" "" ""
+testcmd "match() utf8" "'{print match(\$0, \"ス\")}' < $FILES/utf8/japan.txt"\
+  "5\n" "" ""
 
 testing "awk -e print print ARGC file1 file2" "awk '{ print \$1; print ARGC }' testfile1.txt testfile2.txt" "abc\n3\nghi\n3\nmno\n3\nstu\n3\n\n3\nabc,def,ghi,5\n3\nghi,jkl,mno,10\n3\nmno,pqr,stu,15\n3\nstu,vwx,abc,20\n3\n\n3\n" "" ""
 testing "awk -e print ARGC file" "awk '{ print ARGC }' testfile1.txt" "2\n2\n2\n2\n2\n" "$FILE1" ""

--- a/toybox_awk_test/awk.test
+++ b/toybox_awk_test/awk.test
@@ -419,6 +419,7 @@ testcmd "or()" "'BEGIN{print or(256, 16)}'" "272\n" "" ""
 testcmd "or(a, b, ...)" "'BEGIN{print or(256, 16, 8)}'" "280\n" "" ""
 testcmd "toupper()" "'BEGIN{print toupper(\"abABcD\")}'" "ABABCD\n" "" ""
 testcmd "tolower()" "'BEGIN{print tolower(\"abABcD\")}'" "ababcd\n" "" ""
+testcmd "tolower() utf8" "'{print tolower(\$0)}'" "ğжþ\n" "" "ĞЖÞ"
 testcmd "substr()" "'BEGIN{print substr(\"abac\", 2, 2)}'" "ba\n" "" ""
 testcmd "atan2()" "'BEGIN{print substr(atan2(0, -1), 1, 5)}'" "3.141\n" "" ""
 testcmd "length()" "'{print length()}'" "1\n2\n0\n4\n" "" "a\n12\n\n6502"
@@ -433,6 +434,8 @@ testcmd "match()" "'BEGIN{print match(\"bcdab\", \"ab\")}'" "4\n" "" ""
 testcmd "match() none" "'BEGIN{print match(\"ス\", \"deadbeef\")}'" "0\n" "" ""
 testcmd "match() utf8" "'{print match(\$0, \"ス\")}' < $FILES/utf8/japan.txt"\
   "5\n" "" ""
+
+testcmd "-b" "-b '{print length()}'< $FILES/utf8/japan.txt" "75\n" "" ""
 
 testing "awk -e print print ARGC file1 file2" "awk '{ print \$1; print ARGC }' testfile1.txt testfile2.txt" "abc\n3\nghi\n3\nmno\n3\nstu\n3\n\n3\nabc,def,ghi,5\n3\nghi,jkl,mno,10\n3\nmno,pqr,stu,15\n3\nstu,vwx,abc,20\n3\n\n3\n" "" ""
 testing "awk -e print ARGC file" "awk '{ print ARGC }' testfile1.txt" "2\n2\n2\n2\n2\n" "$FILE1" ""

--- a/toybox_awk_test/awk.test
+++ b/toybox_awk_test/awk.test
@@ -419,7 +419,6 @@ testcmd "or()" "'BEGIN{print or(256, 16)}'" "272\n" "" ""
 testcmd "or(a, b, ...)" "'BEGIN{print or(256, 16, 8)}'" "280\n" "" ""
 testcmd "toupper()" "'BEGIN{print toupper(\"abABcD\")}'" "ABABCD\n" "" ""
 testcmd "tolower()" "'BEGIN{print tolower(\"abABcD\")}'" "ababcd\n" "" ""
-testcmd "tolower() utf8" "'{print tolower(\$0)}'" "ğжþ\n" "" "ĞЖÞ"
 testcmd "substr()" "'BEGIN{print substr(\"abac\", 2, 2)}'" "ba\n" "" ""
 testcmd "atan2()" "'BEGIN{print substr(atan2(0, -1), 1, 5)}'" "3.141\n" "" ""
 testcmd "length()" "'{print length()}'" "1\n2\n0\n4\n" "" "a\n12\n\n6502"
@@ -429,12 +428,15 @@ testcmd "length() utf8" "'{print length()}'< $FILES/utf8/japan.txt" "25\n" "" ""
 testcmd "substr() utf8" "'{print substr(\$0,2,1)}' < $FILES/utf8/arabic.txt" "ل\nأ\n" "" "" 
 testcmd "index() utf8" "'{print index(\$0, \"ス\")}' < $FILES/utf8/japan.txt"\
   "5\n" "" ""
+testcmd "tolower() utf8" "'{print tolower(\$0)}'" "ğжþ\n" "" "ĞЖÞ"
 testcmd "index() none" "'BEGIN{print index(\"ス\", \"deadbeef\")}'" "0\n" "" ""
 testcmd "match()" "'BEGIN{print match(\"bcdab\", \"ab\")}'" "4\n" "" ""
 testcmd "match() none" "'BEGIN{print match(\"ス\", \"deadbeef\")}'" "0\n" "" ""
 testcmd "match() utf8" "'{print match(\$0, \"ス\")}' < $FILES/utf8/japan.txt"\
   "5\n" "" ""
 testcmd "\\u" "'BEGIN{print \"\\u20\u255\"}' < /dev/null" " ɕ\n" "" ""
+testcmd "printf %c" "'BEGIN{a=255; printf \"%c%c%c\", a, b, 255}'"\
+  "ÿ\0ÿ" "" ""
 
 testcmd "-b" "-b '{print length()}'< $FILES/utf8/japan.txt" "75\n" "" ""
 


### PR DESCRIPTION
Sorry, this apparently got auto-closed when I closed another one for the gawk bitwise operations.

A note on combining characters: We don't have to worry about them, at all, UTF-8 safe awks count codepoints,
not columns, so there are no fontmetrics nightmares (goawk not being UTF8 safe was a bit of a shock to me):

```sh
$ for awk in gawk nawk mawk goawk tbawk muwak; do echo -n $awk " "; $awk '{print length()}' tests/files/utf8/test1.txt; done
gawk  115
nawk  115
mawk  207
goawk  207
tbawk  115
muwak  115
```